### PR TITLE
Set DataFrame of accepted results

### DIFF
--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -4,7 +4,6 @@ import pickle
 import polars as pl
 
 
-
 class SimulationBundle:
     """
     A class to keep track of an iteration/generation of simulations (particles)

--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -335,13 +335,10 @@ class SimulationBundle:
     def collate_accept_results(self):
         """
         Makes a single DataFrame attribute from ABC results of accepted, distance, and inputs.
-
         Args:
             self
-
         Returns:
             None
-
         Raises:
             ValueError: if accept is not previously calculated
         """
@@ -349,20 +346,20 @@ class SimulationBundle:
         # Ensure accept is already calculated
         if not hasattr(self, "accepted"):
             raise ValueError("Accept has not been calculated.")
-
+        
         # Ensure accepted and distances have same simulation order
         if not (self.accepted.keys() == self.distances.keys()):
             reshuffle_accept = {
-                k: self.accepted[k] for k in list(self.distances.keys())
-            }
-            self.accepted = reshuffle_accept
+            k: self.accepted[k] for k in list(self.distances.keys())
+        }
+        self.accepted = reshuffle_accept
 
         # Dummy mapper to join distances and accept with inputs
         mapper = pl.DataFrame(
-            {
-                "simulation": list(int(k) for k in self.distances.keys()),
-                "distance": list(self.distances.values()),
-            }
+        {
+            "simulation": list(int(k) for k in self.distances.keys()),
+            "distance": list(self.distances.values()),
+        }
         )
 
         # Joining results with inputs
@@ -373,7 +370,7 @@ class SimulationBundle:
         accept_results = accept_results.with_columns(
             pl.col("simulation").is_in(accepted_sims).alias("accept_bool")
         )
-
+        
         # Store parameters in a DataFrame attribute for later analysis and diagnostics
         self.accept_results = accept_results
 

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -6,8 +6,7 @@ import matplotlib.pyplot as plt
 import polars as pl
 from scipy.stats import uniform
 
-from abctools import abc_methods, plot_utils, toy_model
-from abctools.abc_classes import SimulationBundle
+from abctools import abc_classes, abc_methods, plot_utils, toy_model
 
 # Set random seed
 random_seed = 12345
@@ -206,7 +205,7 @@ class TestABCPipeline(unittest.TestCase):
             print(f"Step {step_number}, trying {len(input_df)} samples")
 
             # Create the simulation bundle for the current step
-            sim_bundle = SimulationBundle(
+            sim_bundle = abc_classes.SimulationBundle(
                 inputs=input_df,
                 step_number=step_number,
                 baseline_params=self.baseline_params,
@@ -286,7 +285,7 @@ class TestABCPipeline(unittest.TestCase):
                     )
 
                     # Create additional SimulationBundle (will be merged into the current step's sim_bundle once evaluated)
-                    additional_sim_bundle = SimulationBundle(
+                    additional_sim_bundle = abc_classes.SimulationBundle(
                         inputs=additional_input_df,
                         step_number=step_number,
                         baseline_params=self.baseline_params,
@@ -329,7 +328,7 @@ class TestABCPipeline(unittest.TestCase):
                 f"Collate accepted simulations, step #{step_number}"
             ):
                 # Collate results from distance calculations
-                sim_bundle.collate_accepted()
+                sim_bundle.collate_accept_results()
 
                 # Ensure the accepted logical column is present
                 self.assertIn(

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -332,9 +332,7 @@ class TestABCPipeline(unittest.TestCase):
                 sim_bundle.collate_accept_results()
 
                 # Ensure the accepted logical column is present
-                self.assertIn(
-                    "accepted_bool", sim_bundle.accept_results.columns
-                )
+                self.assertIn("accept_bool", sim_bundle.accept_results.columns)
 
                 # Ensure the sum of TRUE counts in logical column is the number of accepted sims
                 self.assertEqual(

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -6,7 +6,8 @@ import matplotlib.pyplot as plt
 import polars as pl
 from scipy.stats import uniform
 
-from abctools import abc_classes, abc_methods, plot_utils, toy_model
+from abctools import abc_methods, plot_utils, toy_model
+from abctools.abc_classes import SimulationBundle
 
 # Set random seed
 random_seed = 12345
@@ -205,7 +206,7 @@ class TestABCPipeline(unittest.TestCase):
             print(f"Step {step_number}, trying {len(input_df)} samples")
 
             # Create the simulation bundle for the current step
-            sim_bundle = abc_classes.SimulationBundle(
+            sim_bundle = SimulationBundle(
                 inputs=input_df,
                 step_number=step_number,
                 baseline_params=self.baseline_params,
@@ -285,7 +286,7 @@ class TestABCPipeline(unittest.TestCase):
                     )
 
                     # Create additional SimulationBundle (will be merged into the current step's sim_bundle once evaluated)
-                    additional_sim_bundle = abc_classes.SimulationBundle(
+                    additional_sim_bundle = SimulationBundle(
                         inputs=additional_input_df,
                         step_number=step_number,
                         baseline_params=self.baseline_params,
@@ -332,18 +333,18 @@ class TestABCPipeline(unittest.TestCase):
 
                 # Ensure the accepted logical column is present
                 self.assertIn(
-                    "accepted_sim", sim_bundle.accept_results.columns
+                    "accepted_bool", sim_bundle.accept_results.columns
                 )
 
                 # Ensure the sum of TRUE counts in logical column is the number of accepted sims
                 self.assertEqual(
-                    sim_bundle.accept_results["accepted_sim"].sum(),
+                    sim_bundle.accept_results["accept_bool"].sum(),
                     sim_bundle.n_accepted,
                 )
 
                 # Check that distance values with accepted_sim == True are less than or equal to tolerance
                 accept_above_max = sim_bundle.accept_results.filter(
-                    pl.col("accepted_sim")
+                    pl.col("accept_bool")
                 ).filter(pl.col("distance") > self.tolerance[step_number])
 
                 self.assertTrue(accept_above_max.is_empty())


### PR DESCRIPTION
### Overview
Setter function `collate_accept_results` organzies the distances and accepted dictionaries into one DataFrame that is then stored as a property of the `SimulationBundle`

This is an update to PR #14 and completes the Issue #3 feature request.

### Changes
The getter function from PR #14 is now a setter, without storing the DataFrame in an external variable.