### PR TITLE
Weight by proportion of samples accepted

### DIFF
--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -475,6 +475,9 @@ class SimulationBundle:
         # Merge accepted simulations dictionaries directly
         self.accepted.update(other_bundle.accepted)
 
+        # Merge acceptance weights dictionaries directly
+        self.acceptance_weights.update(other_bundle.acceptance_weights)
+
         # Record the merge event in the history
         current_merge_index = len(self.merge_history) + 1
         number_merged = len(other_bundle.inputs)

--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -270,6 +270,7 @@ class SimulationBundle:
 
         # Initialize accepted simulations dictionary
         self.accepted = {}
+        self.acceptance_weights = {}
 
         # Iterate over simulations and accept those within tolerance
         for sim_number, distance in self.distances.items():
@@ -285,6 +286,7 @@ class SimulationBundle:
 
                 # Add filtered parameters to the dictionary of accepted simulations
                 self.accepted[sim_number] = accepted_params
+                self.acceptance_weights[sim_number] = 1.0
 
     def accept_stochastic(self, tolerance):
         """
@@ -375,6 +377,8 @@ class SimulationBundle:
 
         # Initialize/clear accepted simulations dictionary
         self.accepted = {}
+        self.acceptance_weights = {}
+
 
         # Accept only the top-performing simulations as determined by the specified proportion
         for sim_number, distance in sorted_simulations[:num_to_accept]:
@@ -389,6 +393,7 @@ class SimulationBundle:
 
             # Store parameters of accepted simulations in an attribute for later use or analysis
             self.accepted[sim_number] = accepted_params
+            self.acceptance_weights[sim_number] = 1.0
 
     def collate_accept_results(self):
         """

--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -379,7 +379,6 @@ class SimulationBundle:
         self.accepted = {}
         self.acceptance_weights = {}
 
-
         # Accept only the top-performing simulations as determined by the specified proportion
         for sim_number, distance in sorted_simulations[:num_to_accept]:
             # Retrieve and clean input parameters for each accepted simulation

--- a/abctools/abc_methods.py
+++ b/abctools/abc_methods.py
@@ -8,24 +8,26 @@ from scipy.stats import qmc, truncnorm
 
 def draw_simulation_parameters(
     params_inputs: dict,
-    n_simulations: int,
+    n_parameter_sets: int,
     method: str = "sobol",
     add_random_seed: bool = True,
     add_simulation_id: bool = True,
     starting_simulation_number: int = 0,
     seed=None,
+    replicates_per_particle=1,
 ) -> pl.DataFrame:
     """
     Draw samples of parameters for simulations based on the specified method.
 
     Args:
         params_inputs (dict): Dictionary containing parameters and their distributions.
-        n_simulations (int): Number of simulations to perform.
+        n_parameter_sets (int): Number of simulations to perform.
         method (str): Sampling method ("random", "sobol", or "latin_hypercube").
         add_random_seed (bool): If True, adds a 'randomSeed' column with randomly generated numbers.
         add_simulation_id (bool): If True, adds a 'simulation' column with simulation IDs starting from `starting_simulation_number`.
         starting_simulation_number (int): The number at which to start numbering simulations. Defaults to 0.
         seed (int): Random seed passed in to ensure consistency between runs.
+        replicates_per_particle (int): Number of replicates to generate per parameter set.
 
     Returns:
         pd.DataFrame: DataFrame containing arrays of sampled values for each parameter,
@@ -40,7 +42,7 @@ def draw_simulation_parameters(
     if method == "random":
         # Random sampling for each distribution
         samples = {
-            param_key: dist_obj.rvs(size=n_simulations)
+            param_key: dist_obj.rvs(size=n_parameter_sets)
             for param_key, dist_obj in params_inputs.items()
         }
 
@@ -55,7 +57,7 @@ def draw_simulation_parameters(
         )
 
         # Generate uniform samples across all dimensions
-        uniform_samples = sampler.random(n=n_simulations)
+        uniform_samples = sampler.random(n=n_parameter_sets)
 
         # Transform uniform samples using ppf for each distribution
         samples_transformed = np.column_stack(
@@ -75,7 +77,10 @@ def draw_simulation_parameters(
         raise ValueError(f"Unsupported sampling method: {method}")
 
     # Convert to Polars DataFrame
-    simulation_parameters_df = pl.DataFrame(samples)
+    n_simulations = n_parameter_sets * replicates_per_particle
+    simulation_parameters_df = pl.DataFrame(samples).select(
+        pl.all().repeat_by(replicates_per_particle).flatten()
+    )
 
     if add_random_seed:
         # Add a random seed column with integers between 0 and 2^32 - 1
@@ -86,7 +91,7 @@ def draw_simulation_parameters(
             pl.Series("randomSeed", seed_column)
         )
 
-    # If specified, add a simulation ID column with integers from `starting_simulation_number` to `starting_simulation_number + n_simulations - 1`
+    # If specified, add a simulation ID column with integers from `starting_simulation_number` to `starting_simulation_number + n_parameter_sets - 1`
     if add_simulation_id:
         # Generate sequence using arange and offset by the starting number
         simulation_id_sequence = np.arange(
@@ -109,6 +114,7 @@ def draw_simulation_parameters(
 def resample(
     accepted_simulations,
     n_samples,
+    replicates_per_sample=1,
     perturbation_kernels=None,
     prior_distributions=None,
     weights=None,
@@ -122,6 +128,7 @@ def resample(
     Args:
         accepted_simulations (dict): Dictionary of Polar DataFrames or dictionaries of accepted simulations with parameters.
         n_samples (int): Number of additional samples to generate.
+        replicates_per_sample (int): Number of replicates to generate per sample.
         perturbation_kernels (dict): Dictionary of perturbation kernels for each parameter.
         prior_distributions (dict): Dictionary of prior distributions for each parameter.
         weights (dict or None): Optional dictionary of weights for each accepted simulation. If None, uniform weighting is assumed.
@@ -191,20 +198,27 @@ def resample(
 
         new_samples.append(selected_params)
 
+    n_simulations = n_samples * replicates_per_sample
+    resampled_df = pl.DataFrame(new_samples).select(
+        pl.all().repeat_by(replicates_per_sample).flatten()
+    )
+
     # Convert list of dictionaries to Polars DataFrame and add 'simulation' column starting at desired number
-    resampled_df = pl.DataFrame(new_samples).with_columns(
+    resampled_df = resampled_df.with_columns(
         pl.Series(
             "simulation",
             np.arange(
                 starting_simulation_number,
-                starting_simulation_number + n_samples,
+                starting_simulation_number + n_simulations,
             ),
         )
     )
 
     if add_random_seed:
         # Add a random seed column with integers between 0 and 2^32 - 1
-        seed_column = [random.randint(0, 2**32) for _ in range(n_samples)]
+        seed_column = [
+            random.randint(0, 2**32) for _ in range(n_simulations)
+        ]
         resampled_df = resampled_df.with_columns(
             pl.Series("randomSeed", seed_column)
         )

--- a/abctools/abc_methods.py
+++ b/abctools/abc_methods.py
@@ -216,6 +216,7 @@ def calculate_weights_abcsmc(
     current_accepted,
     prev_step_accepted,
     prev_weights,
+    stochastic_acceptance_weights,
     prior_distributions,
     perturbation_kernels,
     normalize=True,
@@ -270,7 +271,7 @@ def calculate_weights_abcsmc(
         weight = numerator / denominator if denominator != 0 else 0
 
         # Store calculated weight
-        new_weights[sim_number] = weight
+        new_weights[sim_number] = weight * stochastic_acceptance_weights[sim_number]
 
     if normalize:
         # Normalize weights so they sum up to 1

--- a/abctools/abc_methods.py
+++ b/abctools/abc_methods.py
@@ -271,7 +271,9 @@ def calculate_weights_abcsmc(
         weight = numerator / denominator if denominator != 0 else 0
 
         # Store calculated weight
-        new_weights[sim_number] = weight * stochastic_acceptance_weights[sim_number]
+        new_weights[sim_number] = (
+            weight * stochastic_acceptance_weights[sim_number]
+        )
 
     if normalize:
         # Normalize weights so they sum up to 1

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -173,7 +173,7 @@ class TestABCPipeline(unittest.TestCase):
                 with self.subTest("Initialize Samples"):
                     input_df = abc_methods.draw_simulation_parameters(
                         params_inputs=self.experiment_params_prior_dist,
-                        n_simulations=self.n_init,
+                        n_parameter_sets=self.n_init,
                         add_random_seed=self.stochastic,
                         seed=random_seed,
                     )
@@ -187,6 +187,7 @@ class TestABCPipeline(unittest.TestCase):
                         input_df = abc_methods.resample(
                             sim_bundles[step_number - 1].accepted,
                             n_samples=self.n_init,
+                            replicates_per_sample=1,
                             perturbation_kernels=self.perturbation_kernels,
                             prior_distributions=self.experiment_params_prior_dist,
                             weights=sim_bundles[step_number - 1].weights,
@@ -198,6 +199,7 @@ class TestABCPipeline(unittest.TestCase):
                         input_df = abc_methods.resample(
                             sim_bundles[step_number - 1].accepted,
                             n_samples=self.n_init,
+                            replicates_per_sample=1,
                             weights=sim_bundles[step_number - 1].weights,
                             seed=random_seed,
                         )
@@ -265,7 +267,7 @@ class TestABCPipeline(unittest.TestCase):
                     if step_number == 0:
                         additional_input_df = abc_methods.draw_simulation_parameters(
                             params_inputs=self.experiment_params_prior_dist,
-                            n_simulations=n_additional,
+                            n_parameter_sets=n_additional,
                             add_random_seed=self.stochastic,
                             starting_simulation_number=sim_bundle.n_simulations,
                             seed=random_seed,

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -350,19 +350,23 @@ class TestABCPipeline(unittest.TestCase):
             with self.subTest(f"Calculate weights, step #{step_number}"):
                 if step_number == 0:
                     # uniform weights on the initial step
-                    weights = {
-                        key: 1 / len(sim_bundle.accepted)
-                        for key in sim_bundle.accepted
-                    }
+                    weights = {}
+                    for key in sim_bundle.accepted:
+                        weights[key] = sim_bundle.acceptance_weights[
+                            key
+                        ] / len(sim_bundle.accepted)
                 else:
                     prev_step_accepted = sim_bundles[step_number - 1].accepted
                     prev_step_weights = sim_bundles[step_number - 1].weights
+                    accept_ratio_weights = sim_bundle.acceptance_weights
+
                     weights = abc_methods.calculate_weights_abcsmc(
-                        sim_bundle.accepted,
-                        prev_step_accepted,
-                        prev_step_weights,
-                        self.experiment_params_prior_dist,
-                        self.perturbation_kernels,
+                        current_accepted=sim_bundle.accepted,
+                        prev_step_accepted=prev_step_accepted,
+                        prev_weights=prev_step_weights,
+                        stochastic_acceptance_weights=accept_ratio_weights,
+                        prior_distributions=self.experiment_params_prior_dist,
+                        perturbation_kernels=self.perturbation_kernels,
                         normalize=True,
                     )
 


### PR DESCRIPTION
## Overview
Stochastic model fitting within the SMC framework requires weighting by the proportion of simulations that are within the tolerance ([Toni et al. 2009](https://royalsocietypublishing.org/doi/pdf/10.1098/rsif.2008.0172)). In deterministic models, this is equal to 1 or 0, but in stochastic simulations that proportion will vary. Improper weighting results in oversampling from the edges of the proposed posterior instead of the higher performing examples.

## Changes
- added the `stochastic_accept` method
- set the `acceptance_weights`, equal to one in the case of simply accepting/rejecting
- Edited the test to resample based on these weights to show use (even though deterministic)

## Out of scope
- Make these returned values polars data frames rather than dictionaries
- Remove the accept_reject, and accept_proportion methods and replace with accept stochastic taking an input of proportion or tolerance based method