### PR TITLE
Fixed `accept_stochastic`

### DIFF
--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -321,7 +321,7 @@ class SimulationBundle:
         )
 
         # Group by parameters besides simulation and random seed
-        particle_prop_accepted = distances_accepted.groupby(
+        particle_prop_accepted = distances_accepted.group_by(
             self.inputs.drop(["simulation", "randomSeed"]).columns
         ).agg(
             pl.col("accepted_bool").mean().alias("acceptance_weight"),

--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -315,7 +315,7 @@ class SimulationBundle:
         # Group by parameters besides simulation and random seed
         particle_prop_accepted = self.accept_results.group_by(
             self.inputs.drop(
-                ["simulation", "randomSeed", "accept_bool"]
+                ["simulation", "randomSeed"]
             ).columns
         ).agg(
             pl.col("accept_bool").mean().alias("acceptance_weight"),

--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -288,9 +288,13 @@ class SimulationBundle:
                 self.accepted[sim_number] = accepted_params
                 self.acceptance_weights[sim_number] = 1.0
 
-    def accept_stochastic(self, tolerance):
+    def accept_stochastic(
+        self,
+        tolerance,
+    ):
         """
-        Accepts simulations and returns the proportion of simulations accepted for each parameter set
+        Accepts the minimum simulation of each parameter set with greater than zero replicates under the tolerance level
+        Sets the acceptance_weight proportion for each parameter set
 
         Args:
             tolerance (float): The tolerance level for accepting simulations.
@@ -305,26 +309,16 @@ class SimulationBundle:
         if not hasattr(self, "distances"):
             raise ValueError("Distances have not been calculated.")
 
-        self.acceptance_weights = {}
-        self.accepted = {}
-        # Determine accepted particles and seeds
-        distances_accepted = pl.from_dict(
-            {
-                "simulation": self.distances.keys(),
-                "distance": self.distances.values(),
-            }
-        ).with_columns(
-            pl.col("distance")
-            .le(tolerance)
-            .cast(pl.Int8)
-            .alias("accepted_bool"),
-        )
+        self.accept_reject(tolerance)
+        self.collate_accept_results()
 
         # Group by parameters besides simulation and random seed
-        particle_prop_accepted = distances_accepted.group_by(
-            self.inputs.drop(["simulation", "randomSeed"]).columns
+        particle_prop_accepted = self.accept_results.group_by(
+            self.inputs.drop(
+                ["simulation", "randomSeed", "accept_bool"]
+            ).columns
         ).agg(
-            pl.col("accepted_bool").mean().alias("acceptance_weight"),
+            pl.col("accept_bool").mean().alias("acceptance_weight"),
             pl.col("simulation").min().alias("simulation"),
         )
 
@@ -333,6 +327,8 @@ class SimulationBundle:
             pl.col("acceptance_weight") > 0
         )
 
+        self.acceptance_weights = {}
+        self.accepted = {}
         # Create acceptance weights (to be included in the weights assignment) and params dict
         for row in particle_prop_accepted.rows(named=True):
             self.acceptance_weights.update(

--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -314,9 +314,7 @@ class SimulationBundle:
 
         # Group by parameters besides simulation and random seed
         particle_prop_accepted = self.accept_results.group_by(
-            self.inputs.drop(
-                ["simulation", "randomSeed"]
-            ).columns
+            self.inputs.drop(["simulation", "randomSeed"]).columns
         ).agg(
             pl.col("accept_bool").mean().alias("acceptance_weight"),
             pl.col("simulation").min().alias("simulation"),

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -242,9 +242,9 @@ class TestABCPipeline(unittest.TestCase):
                     self.assertGreaterEqual(distance, 0)
 
             with self.subTest(
-                f"Accept or Reject Simulations, step #{step_number}"
+                f"Accept or Reject Simulations through accept_stochastic, step #{step_number}"
             ):
-                sim_bundle.accept_reject(self.tolerance[step_number])
+                sim_bundle.accept_stochastic(self.tolerance[step_number])
 
                 # Ensure at least one simulation is accepted
                 self.assertGreaterEqual(len(sim_bundle.accepted), 1)
@@ -312,7 +312,7 @@ class TestABCPipeline(unittest.TestCase):
                     )
 
                     # Accept or reject the additional simulations based on tolerance criteria
-                    additional_sim_bundle.accept_reject(
+                    additional_sim_bundle.accept_stochastic(
                         self.tolerance[step_number]
                     )
 


### PR DESCRIPTION
## Changes
Minor bugfix for `group_by`, now use `collate_accept_results` and `accept_reject` to arrive at the dataframe for selecting stochastic simulation parameter sets because column names weren't being found in previous setup.

Changed `accept_stochastic` to be the test method in the test module, since it still calls `accept_reject` this remains functionally the same but with added checks