### PR TITLE
SimulationBundle storage refactor: polars dataframes instead of dictionaries

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,8 +11,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pre-commit
+          ~/.cache/R/renv
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: "4.4.0"
         use-public-rspm: true
-    - uses: ./.github/actions/pre-commit
+        r-version: "4.4"
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,7 +21,6 @@ jobs:
         key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: "4.4.0"
         use-public-rspm: true
         r-version: "4.4"
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test_toy_model.yaml
+++ b/.github/workflows/test_toy_model.yaml
@@ -23,4 +23,4 @@ jobs:
 
     - name: Run test
       run: |
-        poetry run python abctools/tests/test_abc_pipeline.py
+        poetry run pytest

--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -291,7 +291,6 @@ class SimulationBundle:
         # Ensure distances have been calculated
         if self.distances.is_empty():
             raise ValueError("Distances have not been calculated.")
-
         # Filter and join to get accepted parameters
         self.accepted = self.distances.with_columns(
             (pl.col("distance") <= tolerance).alias("accept_bool")
@@ -319,7 +318,6 @@ class SimulationBundle:
             raise ValueError("Distances have not been calculated.")
 
         self.accept_reject(tolerance)
-
         # Group by parameters besides simulation and random seed
         param_names = self.inputs.drop(
             ["simulation", self.seed_variable_name]
@@ -335,7 +333,10 @@ class SimulationBundle:
             .filter(
                 pl.col("acceptance_weight") > 0
             )  # Filter particles with accepted count > 0
-            .join(self.accepted, on=param_names, how="full")
+            .join(self.accepted, on=param_names, how="right")
+            .with_columns(
+                pl.col("acceptance_weight").fill_null(strategy="zero")
+            )
         )
 
     def accept_proportion(self, proportion: float):

--- a/abctools/abc_methods.py
+++ b/abctools/abc_methods.py
@@ -151,7 +151,7 @@ def resample(
     new_samples = []
 
     # Normalize weights if provided (just to be safe)
-    if weights is not None:
+    if not weights.is_empty():
         total_weight = weights["weight"].sum()
         weights = weights.with_columns(
             (pl.col("weight") / total_weight).alias("weight")

--- a/abctools/abc_methods.py
+++ b/abctools/abc_methods.py
@@ -172,9 +172,12 @@ def resample(
         weights=sampling_weights.to_list(),
         k=n_samples,
     )
-    # Filter rows based on sampled 'simulation' values
-    sampled_simulations_df = accepted_simulations.filter(
-        pl.col("simulation").is_in(sampled_simulations)
+    # Filter rows based on sampled 'simulation' values, ensuring duplicates are included
+    sampled_simulations_df = pl.concat(
+        [
+            accepted_simulations.filter(pl.col("simulation") == sim)
+            for sim in sampled_simulations
+        ]
     )
 
     # Apply perturbations

--- a/abctools/abc_methods.py
+++ b/abctools/abc_methods.py
@@ -160,15 +160,16 @@ def resample(
             on="simulation",
             how="left",
         )
+        sampling_weights = accepted_simulations["normalized_weight"].to_list()
     else:
-        sampling_weights = pl.Series(
-            [1.0 / len(accepted_simulations)] * len(accepted_simulations)
+        sampling_weights = [1.0 / len(accepted_simulations)] * len(
+            accepted_simulations
         )
 
     # Sample 'simulation' values with replacement using sampling weights
     sampled_simulations = random.choices(
         accepted_simulations["simulation"].to_list(),
-        weights=sampling_weights.to_list(),
+        weights=sampling_weights,
         k=n_samples,
     )
     # Filter rows based on sampled 'simulation' values, ensuring duplicates are included

--- a/abctools/abc_methods.py
+++ b/abctools/abc_methods.py
@@ -18,6 +18,7 @@ def draw_simulation_parameters(
     add_simulation_id: bool = True,
     starting_simulation_number: int = 0,
     seed=random.randint(0, 2**32 - 1),
+    seed_variable_name: str = "randomSeed",
     replicates_per_particle=1,
 ) -> pl.DataFrame:
     """
@@ -27,7 +28,7 @@ def draw_simulation_parameters(
         params_inputs (dict): Dictionary containing parameters and their distributions.
         n_parameter_sets (int): Number of simulations to perform.
         method (str): Sampling method ("random", "sobol", or "latin_hypercube").
-        add_random_seed (bool): If True, adds a 'randomSeed' column with randomly generated numbers.
+        add_random_seed (bool): If True, adds a random seed column with randomly generated numbers.
         add_simulation_id (bool): If True, adds a 'simulation' column with simulation IDs starting from `starting_simulation_number`.
         starting_simulation_number (int): The number at which to start numbering simulations. Defaults to 0.
         seed (int): Random seed passed in to ensure consistency between runs.
@@ -92,7 +93,7 @@ def draw_simulation_parameters(
             random.randint(0, 2**32) for _ in range(n_simulations)
         ]
         simulation_parameters_df = simulation_parameters_df.with_columns(
-            pl.Series("randomSeed", seed_column)
+            pl.Series(seed_variable_name, seed_column)
         )
 
     # If specified, add a simulation ID column with integers from `starting_simulation_number` to `starting_simulation_number + n_parameter_sets - 1`
@@ -125,6 +126,7 @@ def resample(
     add_random_seed: bool = True,
     starting_simulation_number: int = 0,
     seed: int = None,
+    seed_variable_name: str = "randomSeed",
 ) -> pl.DataFrame:
     """
     Resamples parameters from accepted simulations with optional perturbation and reweighting.
@@ -136,7 +138,7 @@ def resample(
         perturbation_kernels (dict): Dictionary of perturbation kernels for each parameter.
         prior_distributions (dict): Dictionary of prior distributions for each parameter.
         weights (pl.DataFrame or None): Optional DataFrame of weights for each accepted simulation. If None, uniform weighting is assumed.
-        add_random_seed (bool): If True, adds a 'randomSeed' column with randomly generated numbers.
+        add_random_seed (bool): If True, adds a random seed column with randomly generated numbers.
         starting_simulation_number (int): Starting number for new simulation IDs.
         seed (int): Random seed passed in to ensure consistency between runs.
 
@@ -157,9 +159,6 @@ def resample(
             weights.select(["simulation", "normalized_weight"]),
             on="simulation",
             how="left",
-        )
-        sampling_weights = accepted_simulations["normalized_weight"].fill_null(
-            1.0 / len(accepted_simulations)
         )
     else:
         sampling_weights = pl.Series(
@@ -209,7 +208,7 @@ def resample(
         # Add a random seed column with integers between 0 and 2^32 - 1
         resampled_df = resampled_df.with_columns(
             pl.Series(
-                "randomSeed",
+                seed_variable_name,
                 np.random.randint(0, 2**32 - 1, size=len(resampled_df)),
             )
         )

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -225,7 +225,7 @@ class TestABCPipeline(unittest.TestCase):
                             prior_distributions=self.experiment_params_prior_dist,
                             weights=sim_bundles[step_number - 1].weights,
                         )
-                        self.assertEqual(input_df.shape[0], self.n_init)
+                        self.assertEqual(len(input_df), self.n_init)
                 else:
                     with self.subTest(f"Resample, final step #{step_number}"):
                         input_df = abc_methods.resample(

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -369,23 +369,18 @@ class TestABCPipeline(unittest.TestCase):
             with self.subTest(
                 f"Collate accepted simulations, step #{step_number}"
             ):
-                # Collate results from distance calculations
-                sim_bundle.collate_accept_results()
-
                 # Ensure the accepted logical column is present
-                self.assertIn("accept_bool", sim_bundle.accept_results.columns)
+                self.assertIn("accept_bool", sim_bundle.accepted.columns)
 
                 # Ensure the sum of TRUE counts in logical column is the number of accepted sims
                 self.assertEqual(
-                    sim_bundle.accept_results["accept_bool"].sum(),
+                    sim_bundle.accepted["accept_bool"].sum(),
                     sim_bundle.n_accepted,
                 )
-
-                print()
                 # Check that distance values with accepted_sim == True are less than or equal to tolerance
-                accept_above_max = sim_bundle.accept_results.filter(
-                    pl.col("accept_bool")
-                ).filter(pl.col("distance") > self.tolerance[step_number])
+                accept_above_max = sim_bundle.get_accepted().filter(
+                    pl.col("distance") > self.tolerance[step_number]
+                )
                 self.assertTrue(accept_above_max.is_empty())
 
             with self.subTest(f"Calculate weights, step #{step_number}"):

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -1,8 +1,10 @@
 import math
 import os
+import random
 import unittest
 
 import matplotlib.pyplot as plt
+import numpy as np
 import polars as pl
 from scipy.stats import uniform
 
@@ -11,6 +13,8 @@ from abctools.abc_classes import SimulationBundle
 
 # Set random seed
 random_seed = 12345
+random.seed(random_seed)
+np.random.seed(random.randint(0, 2**32 - 1))
 
 
 def run_toy_model(params: dict):
@@ -204,7 +208,7 @@ class TestABCPipeline(unittest.TestCase):
                         params_inputs=self.experiment_params_prior_dist,
                         n_parameter_sets=self.n_init,
                         add_random_seed=self.stochastic,
-                        seed=random_seed,
+                        seed=random.randint(0, 2**32 - 1),
                     )
                     self.assertEqual(input_df.shape[0], self.n_init)
             else:
@@ -220,7 +224,6 @@ class TestABCPipeline(unittest.TestCase):
                             perturbation_kernels=self.perturbation_kernels,
                             prior_distributions=self.experiment_params_prior_dist,
                             weights=sim_bundles[step_number - 1].weights,
-                            seed=random_seed,
                         )
                         self.assertEqual(input_df.shape[0], self.n_init)
                 else:
@@ -230,7 +233,6 @@ class TestABCPipeline(unittest.TestCase):
                             n_samples=self.n_init,
                             replicates_per_sample=1,
                             weights=sim_bundles[step_number - 1].weights,
-                            seed=random_seed,
                         )
                         self.assertEqual(input_df.shape[0], self.n_init)
 
@@ -305,7 +307,7 @@ class TestABCPipeline(unittest.TestCase):
                             n_parameter_sets=n_additional,
                             add_random_seed=self.stochastic,
                             starting_simulation_number=sim_bundle.n_simulations,
-                            seed=random_seed,
+                            seed=random.randint(0, 2**32 - 1),
                         )
                     else:
                         additional_input_df = abc_methods.resample(
@@ -315,7 +317,6 @@ class TestABCPipeline(unittest.TestCase):
                             prior_distributions=self.experiment_params_prior_dist,
                             weights=sim_bundles[step_number - 1].weights,
                             starting_simulation_number=sim_bundle.n_simulations,
-                            seed=random_seed,
                         )
 
                     print(
@@ -380,6 +381,7 @@ class TestABCPipeline(unittest.TestCase):
                     sim_bundle.n_accepted,
                 )
 
+                print()
                 # Check that distance values with accepted_sim == True are less than or equal to tolerance
                 accept_above_max = sim_bundle.accept_results.filter(
                     pl.col("accept_bool")
@@ -397,13 +399,11 @@ class TestABCPipeline(unittest.TestCase):
                 else:
                     prev_step_accepted = sim_bundles[step_number - 1].accepted
                     prev_step_weights = sim_bundles[step_number - 1].weights
-                    accept_ratio_weights = sim_bundle.acceptance_weights
 
                     weights = abc_methods.calculate_weights_abcsmc(
                         current_accepted=sim_bundle.accepted,
                         prev_step_accepted=prev_step_accepted,
                         prev_weights=prev_step_weights,
-                        stochastic_acceptance_weights=accept_ratio_weights,
                         prior_distributions=self.experiment_params_prior_dist,
                         perturbation_kernels=self.perturbation_kernels,
                         normalize=True,

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -56,19 +56,25 @@ def run_toy_model(params: dict):
 
 def run_experiment_sequence(
     simulations_df: pl.DataFrame, summary_function=None
-):
-    """Takes in Polars Dataframe of simulation (full) parameter data and outputs complete or summarized results from a stochastic SIR model"""
-    results_dict = {}
+) -> pl.DataFrame:
+    """Takes in Polars DataFrame of simulation (full) parameter data and outputs complete or summarized results from a stochastic SIR model"""
+    results_list = []
     for simulation_params in simulations_df.rows(named=True):
         results = run_toy_model(simulation_params)
 
         if summary_function:
             summarized_results = summary_function(results)
-            results_dict[simulation_params["simulation"]] = summarized_results
+            results_list.append({
+                "simulation": simulation_params["simulation"],
+                "summary_metrics": summarized_results
+            })
         else:
-            results_dict[simulation_params["simulation"]] = results
+            results_list.append({
+                "simulation": simulation_params["simulation"],
+                "results": results
+            })
 
-    return results_dict
+    return pl.DataFrame(results_list)
 
 
 def calculate_infection_metrics(df):

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -215,9 +215,10 @@ class TestABCPipeline(unittest.TestCase):
             )
 
             with self.subTest(f"Run Model, step #{step_number}"):
-                sim_bundle.results = run_experiment_sequence(
+                results = run_experiment_sequence(
                     sim_bundle.full_params_df
                 )
+                sim_bundle.add_results(results)
                 self.assertEqual(len(sim_bundle.results), self.n_init)
                 self.assertIn("time", sim_bundle.results[0].columns)
                 self.assertIn("infected", sim_bundle.results[0].columns)
@@ -295,9 +296,10 @@ class TestABCPipeline(unittest.TestCase):
                     )
 
                     # Run model for additional simulations
-                    additional_sim_bundle.results = run_experiment_sequence(
+                    additional_results = run_experiment_sequence(
                         additional_sim_bundle.full_params_df
                     )
+                    additional_sim_bundle.add_results(additional_results)
 
                     # Calculate summary metrics for the additional simulations
                     additional_sim_bundle.calculate_summary_metrics(

--- a/abctools/tests/test_simulation_bundle.py
+++ b/abctools/tests/test_simulation_bundle.py
@@ -1,29 +1,31 @@
 import polars as pl
+
 from abctools.abc_classes import SimulationBundle
 
+
 def test_accept_stochastic():
-    inputs = pl.DataFrame({
-        "simulation": range(10),
-        "seed": [0] * 10
-    }).with_columns(
-        (pl.col("simulation") * 0.5).floor().alias("parameter1")
-    )
+    inputs = pl.DataFrame(
+        {"simulation": range(10), "seed": [0] * 10}
+    ).with_columns((pl.col("simulation") * 0.5).floor().alias("parameter1"))
 
     bundle = SimulationBundle(
         inputs=inputs,
         step_number=0,
         baseline_params={},
-        seed_variable_name="seed"
+        seed_variable_name="seed",
     )
 
-    bundle.distances = pl.DataFrame({
-        "simulation": range(10),
-    }).with_columns(
-        (pl.col("simulation") * 0.1).alias("distance")
-    )
+    bundle.distances = pl.DataFrame(
+        {
+            "simulation": range(10),
+        }
+    ).with_columns((pl.col("simulation") * 0.1).alias("distance"))
     bundle.accept_stochastic(tolerance=0.4)
     accepted_totals = bundle.accepted.select(
         pl.sum("acceptance_weight", "accept_bool")
     )
 
-    assert accepted_totals["acceptance_weight"].item() == accepted_totals["accept_bool"].item()
+    assert (
+        accepted_totals["acceptance_weight"].item()
+        == accepted_totals["accept_bool"].item()
+    )

--- a/abctools/tests/test_simulation_bundle.py
+++ b/abctools/tests/test_simulation_bundle.py
@@ -1,0 +1,29 @@
+import polars as pl
+from abctools.abc_classes import SimulationBundle
+
+def test_accept_stochastic():
+    inputs = pl.DataFrame({
+        "simulation": range(10),
+        "seed": [0] * 10
+    }).with_columns(
+        (pl.col("simulation") * 0.5).floor().alias("parameter1")
+    )
+
+    bundle = SimulationBundle(
+        inputs=inputs,
+        step_number=0,
+        baseline_params={},
+        seed_variable_name="seed"
+    )
+
+    bundle.distances = pl.DataFrame({
+        "simulation": range(10),
+    }).with_columns(
+        (pl.col("simulation") * 0.1).alias("distance")
+    )
+    bundle.accept_stochastic(tolerance=0.4)
+    accepted_totals = bundle.accepted.select(
+        pl.sum("acceptance_weight", "accept_bool")
+    )
+
+    assert accepted_totals["acceptance_weight"].item() == accepted_totals["accept_bool"].item()

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,7 +41,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main"]
-markers = "platform_system == \"Windows\""
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -148,6 +148,25 @@ files = [
     {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
     {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
 ]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
+    {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
@@ -280,6 +299,18 @@ test = ["flufl.flake8", "importlib-resources (>=1.3) ; python_version < \"3.9\""
 type = ["pytest-mypy"]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.4.8"
 description = "A fast implementation of the Cassowary constraint solver"
@@ -371,46 +402,46 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.10.0"
+version = "3.10.3"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "matplotlib-3.10.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2c5829a5a1dd5a71f0e31e6e8bb449bc0ee9dbfb05ad28fc0c6b55101b3a4be6"},
-    {file = "matplotlib-3.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a2a43cbefe22d653ab34bb55d42384ed30f611bcbdea1f8d7f431011a2e1c62e"},
-    {file = "matplotlib-3.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:607b16c8a73943df110f99ee2e940b8a1cbf9714b65307c040d422558397dac5"},
-    {file = "matplotlib-3.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01d2b19f13aeec2e759414d3bfe19ddfb16b13a1250add08d46d5ff6f9be83c6"},
-    {file = "matplotlib-3.10.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e6c6461e1fc63df30bf6f80f0b93f5b6784299f721bc28530477acd51bfc3d1"},
-    {file = "matplotlib-3.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:994c07b9d9fe8d25951e3202a68c17900679274dadfc1248738dcfa1bd40d7f3"},
-    {file = "matplotlib-3.10.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:fd44fc75522f58612ec4a33958a7e5552562b7705b42ef1b4f8c0818e304a363"},
-    {file = "matplotlib-3.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c58a9622d5dbeb668f407f35f4e6bfac34bb9ecdcc81680c04d0258169747997"},
-    {file = "matplotlib-3.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:845d96568ec873be63f25fa80e9e7fae4be854a66a7e2f0c8ccc99e94a8bd4ef"},
-    {file = "matplotlib-3.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5439f4c5a3e2e8eab18e2f8c3ef929772fd5641876db71f08127eed95ab64683"},
-    {file = "matplotlib-3.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4673ff67a36152c48ddeaf1135e74ce0d4bce1bbf836ae40ed39c29edf7e2765"},
-    {file = "matplotlib-3.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:7e8632baebb058555ac0cde75db885c61f1212e47723d63921879806b40bec6a"},
-    {file = "matplotlib-3.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4659665bc7c9b58f8c00317c3c2a299f7f258eeae5a5d56b4c64226fca2f7c59"},
-    {file = "matplotlib-3.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d44cb942af1693cced2604c33a9abcef6205601c445f6d0dc531d813af8a2f5a"},
-    {file = "matplotlib-3.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a994f29e968ca002b50982b27168addfd65f0105610b6be7fa515ca4b5307c95"},
-    {file = "matplotlib-3.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b0558bae37f154fffda54d779a592bc97ca8b4701f1c710055b609a3bac44c8"},
-    {file = "matplotlib-3.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:503feb23bd8c8acc75541548a1d709c059b7184cde26314896e10a9f14df5f12"},
-    {file = "matplotlib-3.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:c40ba2eb08b3f5de88152c2333c58cee7edcead0a2a0d60fcafa116b17117adc"},
-    {file = "matplotlib-3.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96f2886f5c1e466f21cc41b70c5a0cd47bfa0015eb2d5793c88ebce658600e25"},
-    {file = "matplotlib-3.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:12eaf48463b472c3c0f8dbacdbf906e573013df81a0ab82f0616ea4b11281908"},
-    {file = "matplotlib-3.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fbbabc82fde51391c4da5006f965e36d86d95f6ee83fb594b279564a4c5d0d2"},
-    {file = "matplotlib-3.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad2e15300530c1a94c63cfa546e3b7864bd18ea2901317bae8bbf06a5ade6dcf"},
-    {file = "matplotlib-3.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3547d153d70233a8496859097ef0312212e2689cdf8d7ed764441c77604095ae"},
-    {file = "matplotlib-3.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c55b20591ced744aa04e8c3e4b7543ea4d650b6c3c4b208c08a05b4010e8b442"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9ade1003376731a971e398cc4ef38bb83ee8caf0aee46ac6daa4b0506db1fd06"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:95b710fea129c76d30be72c3b38f330269363fbc6e570a5dd43580487380b5ff"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cdbaf909887373c3e094b0318d7ff230b2ad9dcb64da7ade654182872ab2593"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d907fddb39f923d011875452ff1eca29a9e7f21722b873e90db32e5d8ddff12e"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3b427392354d10975c1d0f4ee18aa5844640b512d5311ef32efd4dd7db106ede"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5fd41b0ec7ee45cd960a8e71aea7c946a28a0b8a4dcee47d2856b2af051f334c"},
-    {file = "matplotlib-3.10.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:81713dd0d103b379de4516b861d964b1d789a144103277769238c732229d7f03"},
-    {file = "matplotlib-3.10.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:359f87baedb1f836ce307f0e850d12bb5f1936f70d035561f90d41d305fdacea"},
-    {file = "matplotlib-3.10.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae80dc3a4add4665cf2faa90138384a7ffe2a4e37c58d83e115b54287c4f06ef"},
-    {file = "matplotlib-3.10.0.tar.gz", hash = "sha256:b886d02a581b96704c9d1ffe55709e49b4d2d52709ccebc4be42db856e511278"},
+    {file = "matplotlib-3.10.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:213fadd6348d106ca7db99e113f1bea1e65e383c3ba76e8556ba4a3054b65ae7"},
+    {file = "matplotlib-3.10.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d3bec61cb8221f0ca6313889308326e7bb303d0d302c5cc9e523b2f2e6c73deb"},
+    {file = "matplotlib-3.10.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c21ae75651c0231b3ba014b6d5e08fb969c40cdb5a011e33e99ed0c9ea86ecb"},
+    {file = "matplotlib-3.10.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a49e39755580b08e30e3620efc659330eac5d6534ab7eae50fa5e31f53ee4e30"},
+    {file = "matplotlib-3.10.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cf4636203e1190871d3a73664dea03d26fb019b66692cbfd642faafdad6208e8"},
+    {file = "matplotlib-3.10.3-cp310-cp310-win_amd64.whl", hash = "sha256:fd5641a9bb9d55f4dd2afe897a53b537c834b9012684c8444cc105895c8c16fd"},
+    {file = "matplotlib-3.10.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0ef061f74cd488586f552d0c336b2f078d43bc00dc473d2c3e7bfee2272f3fa8"},
+    {file = "matplotlib-3.10.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d96985d14dc5f4a736bbea4b9de9afaa735f8a0fc2ca75be2fa9e96b2097369d"},
+    {file = "matplotlib-3.10.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c5f0283da91e9522bdba4d6583ed9d5521566f63729ffb68334f86d0bb98049"},
+    {file = "matplotlib-3.10.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fdfa07c0ec58035242bc8b2c8aae37037c9a886370eef6850703d7583e19964b"},
+    {file = "matplotlib-3.10.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c0b9849a17bce080a16ebcb80a7b714b5677d0ec32161a2cc0a8e5a6030ae220"},
+    {file = "matplotlib-3.10.3-cp311-cp311-win_amd64.whl", hash = "sha256:eef6ed6c03717083bc6d69c2d7ee8624205c29a8e6ea5a31cd3492ecdbaee1e1"},
+    {file = "matplotlib-3.10.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0ab1affc11d1f495ab9e6362b8174a25afc19c081ba5b0775ef00533a4236eea"},
+    {file = "matplotlib-3.10.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a818d8bdcafa7ed2eed74487fdb071c09c1ae24152d403952adad11fa3c65b4"},
+    {file = "matplotlib-3.10.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:748ebc3470c253e770b17d8b0557f0aa85cf8c63fd52f1a61af5b27ec0b7ffee"},
+    {file = "matplotlib-3.10.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed70453fd99733293ace1aec568255bc51c6361cb0da94fa5ebf0649fdb2150a"},
+    {file = "matplotlib-3.10.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dbed9917b44070e55640bd13419de83b4c918e52d97561544814ba463811cbc7"},
+    {file = "matplotlib-3.10.3-cp312-cp312-win_amd64.whl", hash = "sha256:cf37d8c6ef1a48829443e8ba5227b44236d7fcaf7647caa3178a4ff9f7a5be05"},
+    {file = "matplotlib-3.10.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9f2efccc8dcf2b86fc4ee849eea5dcaecedd0773b30f47980dc0cbeabf26ec84"},
+    {file = "matplotlib-3.10.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3ddbba06a6c126e3301c3d272a99dcbe7f6c24c14024e80307ff03791a5f294e"},
+    {file = "matplotlib-3.10.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:748302b33ae9326995b238f606e9ed840bf5886ebafcb233775d946aa8107a15"},
+    {file = "matplotlib-3.10.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a80fcccbef63302c0efd78042ea3c2436104c5b1a4d3ae20f864593696364ac7"},
+    {file = "matplotlib-3.10.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:55e46cbfe1f8586adb34f7587c3e4f7dedc59d5226719faf6cb54fc24f2fd52d"},
+    {file = "matplotlib-3.10.3-cp313-cp313-win_amd64.whl", hash = "sha256:151d89cb8d33cb23345cd12490c76fd5d18a56581a16d950b48c6ff19bb2ab93"},
+    {file = "matplotlib-3.10.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c26dd9834e74d164d06433dc7be5d75a1e9890b926b3e57e74fa446e1a62c3e2"},
+    {file = "matplotlib-3.10.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:24853dad5b8c84c8c2390fc31ce4858b6df504156893292ce8092d190ef8151d"},
+    {file = "matplotlib-3.10.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68f7878214d369d7d4215e2a9075fef743be38fa401d32e6020bab2dfabaa566"},
+    {file = "matplotlib-3.10.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6929fc618cb6db9cb75086f73b3219bbb25920cb24cee2ea7a12b04971a4158"},
+    {file = "matplotlib-3.10.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6c7818292a5cc372a2dc4c795e5c356942eb8350b98ef913f7fda51fe175ac5d"},
+    {file = "matplotlib-3.10.3-cp313-cp313t-win_amd64.whl", hash = "sha256:4f23ffe95c5667ef8a2b56eea9b53db7f43910fa4a2d5472ae0f72b64deab4d5"},
+    {file = "matplotlib-3.10.3-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:86ab63d66bbc83fdb6733471d3bff40897c1e9921cba112accd748eee4bce5e4"},
+    {file = "matplotlib-3.10.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:a48f9c08bf7444b5d2391a83e75edb464ccda3c380384b36532a0962593a1751"},
+    {file = "matplotlib-3.10.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb73d8aa75a237457988f9765e4dfe1c0d2453c5ca4eabc897d4309672c8e014"},
+    {file = "matplotlib-3.10.3.tar.gz", hash = "sha256:2f82d2c5bb7ae93aaaa4cd42aca65d76ce6376f83304fa3a630b569aca274df0"},
 ]
 
 [package.dependencies]
@@ -729,6 +760,22 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-
 type = ["mypy (>=1.11.2)"]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
 name = "polars"
 version = "1.19.0"
 description = "Blazingly fast DataFrame library"
@@ -843,6 +890,21 @@ numpy = ">=1.16.6"
 test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
+    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pyparsing"
 version = "3.2.1"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -930,6 +992,30 @@ files = [
     {file = "PyQt6_sip-13.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:8c207528992d59b0801458aa6fcff118e5c099608ef0fc6ff8bccbdc23f29c04"},
     {file = "pyqt6_sip-13.9.1.tar.gz", hash = "sha256:15be741d1ae8c82bb7afe9a61f3cf8c50457f7d61229a1c39c24cd6e8f4d86dc"},
 ]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
+    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -1151,6 +1237,49 @@ numpy = "*"
 scipy = "*"
 
 [[package]]
+name = "tomli"
+version = "2.2.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
+    {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8"},
+    {file = "tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff"},
+    {file = "tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b"},
+    {file = "tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"},
+    {file = "tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"},
+    {file = "tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98"},
+    {file = "tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4"},
+    {file = "tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"},
+    {file = "tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744"},
+    {file = "tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec"},
+    {file = "tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69"},
+    {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
+    {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
@@ -1171,6 +1300,19 @@ discord = ["requests"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.1"
+description = "Backported and Experimental Type Hints for Python 3.9+"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
+    {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
+]
 
 [[package]]
 name = "tzdata"
@@ -1228,4 +1370,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "3c4eeb9b04ca98f824ec3276d7599d158083058a10ccf5ecd19e50b1dc008258"
+content-hash = "0d2c13600b21f319543f170c8f44cae9c2e1ed2e783760f31509d94b79a41225"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "abctools"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["CDC/CFA - Team CMEI"]
 readme = "README.md"
@@ -17,6 +17,8 @@ pyqt6 = "^6.7.1"
 pyarrow = "^17.0.0"
 tqdm = "^4.66.5"
 polars = "^1.6.0"
+matplotlib = "^3.10.3"
+pytest = "^8.4.1"
 
 
 [build-system]


### PR DESCRIPTION
Purpose: SimulationBundle class had been storing data in a mix of dictionaries and (Polars) dataframes. Moving to a pure dataframe approach will simplify and ease implementation

What changed? results, distances, accepted, weights, and summary_metrics attributes in the SimulationBundle class are now Polars dataframes. abc_methods resample and calculate_weights_abcsmc, as well as the pipeline test, were updated accordingly